### PR TITLE
Add support for working with IS 7.0.0

### DIFF
--- a/components/org.wso2.carbon.identity.oauth2.grant.rest.core/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.grant.rest.core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.oauth2.grant.rest</groupId>
         <artifactId>identity.oauth2.grant.auth.rest</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.oauth2.grant.rest.core/src/main/java/org/wso2/carbon/identity/oauth2/grant/rest/core/constant/Constants.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.rest.core/src/main/java/org/wso2/carbon/identity/oauth2/grant/rest/core/constant/Constants.java
@@ -42,6 +42,10 @@ public class Constants {
     public static final String FLOW_ID_VALIDITY_PERIOD = "RestAuth.FlowIdValidityPeriod";
     public static final String AUTH_SHOW_FAILURE_REASON = "RestAuth.showValidationFailureReason";
     public static final String FLOW_ID_TIMESTAMP_SKEW = "RestAuth.timestampSkew";
+    public static final String SMS_OTP_AUTHENTICATOR_ALIAS_CONF = "RestAuth.smsOtpAuthenticatorAlias";
+    public static final String EMAIL_OTP_AUTHENTICATOR_ALIAS_CONF = "RestAuth.emailOtpAuthenticatorAlias";
+    public static final String LOCAL_EMAIL_OPT_AUTHENTICATOR_NAME = "email-otp-authenticator";
+    public static final String LOCAL_SMS_OPT_AUTHENTICATOR_NAME = "sms-otp-authenticator";
     public static final String AUTHENTICATOR_NAME_BASIC_AUTH = "BasicAuthenticator";
     public static final String AUTHENTICATOR_NAME_IDENTIFIER_FIRST = "IdentifierExecutor";
     public static final String AUTHENTICATOR_NAME_SMSOTP = "SMSOTP";

--- a/components/org.wso2.carbon.identity.oauth2.grant.rest.core/src/main/java/org/wso2/carbon/identity/oauth2/grant/rest/core/dto/ConfigsDTO.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.rest.core/src/main/java/org/wso2/carbon/identity/oauth2/grant/rest/core/dto/ConfigsDTO.java
@@ -30,6 +30,8 @@ public class ConfigsDTO {
 	private boolean sendNotificationTargetInInitResponse;
 	private String emailAddressRegex;
 	private String mobileNumberRegex;
+	private String emailOtpAuthenticatorAlias;
+	private String smsOtpAuthenticatorAlias;
 
 	public void setEnabled(boolean enabled) {
 
@@ -96,6 +98,26 @@ public class ConfigsDTO {
 		this.mobileNumberRegex = mobileNumberRegex;
 	}
 
+	public String getEmailOtpAuthenticatorAlias() {
+
+		return emailOtpAuthenticatorAlias;
+	}
+
+	public void setEmailOtpAuthenticatorAlias(String emailOtpAuthenticatorAlias) {
+
+		this.emailOtpAuthenticatorAlias = emailOtpAuthenticatorAlias;
+	}
+
+	public String getSmsOtpAuthenticatorAlias() {
+
+		return smsOtpAuthenticatorAlias;
+	}
+
+	public void setSmsOtpAuthenticatorAlias(String smsOtpAuthenticatorAlias) {
+
+		this.smsOtpAuthenticatorAlias = smsOtpAuthenticatorAlias;
+	}
+
 	@Override
 	public String toString() {
 		return "ConfigsDTO{" +
@@ -106,6 +128,8 @@ public class ConfigsDTO {
 				", sendNotificationTargetInInitResponse=" + sendNotificationTargetInInitResponse +
 				", emailAddressRegex='" + emailAddressRegex +
 				", mobileNumberRegex='" + mobileNumberRegex +
+				", emailOtpAuthenticatorAlias='" + emailOtpAuthenticatorAlias +
+				", smsOtpAuthenticatorAlias='" + smsOtpAuthenticatorAlias +
 				'}';
 	}
 }

--- a/components/org.wso2.carbon.identity.oauth2.grant.rest.core/src/main/java/org/wso2/carbon/identity/oauth2/grant/rest/core/util/RestAuthUtil.java
+++ b/components/org.wso2.carbon.identity.oauth2.grant.rest.core/src/main/java/org/wso2/carbon/identity/oauth2/grant/rest/core/util/RestAuthUtil.java
@@ -161,6 +161,18 @@ public class RestAuthUtil {
         String mobileNumberRegexValue = StringUtils.trim(properties.getProperty(Constants.MOBILE_NUMBER_REGEX));
         String mobileNumberRegex = StringUtils.isNotEmpty(mobileNumberRegexValue) ? mobileNumberRegexValue : null;
         configs.setMobileNumberRegex(mobileNumberRegex);
+
+        String emailOtpAuthenticatorAliasValue = StringUtils.trim(
+                properties.getProperty(Constants.EMAIL_OTP_AUTHENTICATOR_ALIAS_CONF));
+        String emailOtpAuthenticatorAlias = StringUtils.isNotEmpty(emailOtpAuthenticatorAliasValue) ?
+                emailOtpAuthenticatorAliasValue : null;
+        configs.setEmailOtpAuthenticatorAlias(emailOtpAuthenticatorAlias);
+
+        String smsOtpAuthenticatorAliasValue = StringUtils.trim(
+                properties.getProperty(Constants.SMS_OTP_AUTHENTICATOR_ALIAS_CONF));
+        String smsOtpAuthenticatorAlias = StringUtils.isNotEmpty(smsOtpAuthenticatorAliasValue) ?
+                smsOtpAuthenticatorAliasValue : null;
+        configs.setSmsOtpAuthenticatorAlias(smsOtpAuthenticatorAlias);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.oauth2.grant.rest.core/src/main/resources/rest-auth.properties
+++ b/components/org.wso2.carbon.identity.oauth2.grant.rest.core/src/main/resources/rest-auth.properties
@@ -37,6 +37,16 @@ RestAuth.emailAddressRegex=(?<=.{1}).(?=.*@)
 #Mobile Number Masking Pattern
 RestAuth.mobileNumberRegex=(\\d)(?=\\d{4})
 
+#SMS OTP authenticator name sent in the request when the local sms otp authenticator is configured in the app
+#When configured the same alias will be used in the responses instead of the local sms otp authenticator name
+#If the local sms otp authenticator is not configured then this property can be omitted
+RestAuth.smsOtpAuthenticatorAlias=sms-otp-authenticator
+
+#Email OTP authenticator name sent in the request when the local email otp authenticator is configured in the app
+#When configured the same alias will be used in the responses instead of the local email otp authenticator name
+#If the local email otp authenticator is not configured then this property can be omitted
+RestAuth.emailOtpAuthenticatorAlias=email-otp-authenticator
+
 #Connector Error Message;Code;Description
 #Client Side Errors
 RestClient.mandatoryParamsEmpty=REST-60001;Mandatory parameters not found;Mandatory parameters not found

--- a/components/org.wso2.carbon.identity.oauth2.grant.rest.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.grant.rest.endpoint/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.oauth2.grant.rest</groupId>
         <artifactId>identity.oauth2.grant.auth.rest</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.oauth2.grant.rest.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.oauth2.grant.rest.handler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.oauth2.grant.rest</groupId>
         <artifactId>identity.oauth2.grant.auth.rest</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.identity.oauth2.grant.rest</groupId>
     <artifactId>identity.oauth2.grant.auth.rest</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Identity OAuth2 Grant Rest</name>
     <url>http://wso2.org</url>
@@ -568,11 +568,11 @@
         <commons-lang.version.range>[2.6.0,4.0.0)</commons-lang.version.range>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
-        <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
+        <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
-        <carbon.identity.version.range>[5.14.0, 6.0.0)</carbon.identity.version.range>
-        <identity.governance.imp.pkg.version.range>[1.3.9, 2.0.0)</identity.governance.imp.pkg.version.range>
-        <carbon.identity.package.import.version.range>[5.14.0, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.version.range>[5.14.0, 8.0.0)</carbon.identity.version.range>
+        <identity.governance.imp.pkg.version.range>[1.3.9, 3.0.0)</identity.governance.imp.pkg.version.range>
+        <carbon.identity.package.import.version.range>[5.14.0, 8.0.0)</carbon.identity.package.import.version.range>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <commons-codec.version>1.4.0.wso2v1</commons-codec.version>


### PR DESCRIPTION
## Purpose
This PR adds support for the REST Authentication Connector to work in Identity Server 7.0.0 

After Identity Server 7.0.0 new local authenticators were introduced for SMS and Email OTP. This PR also adds the ability to check against a set authenticator name alias in order for API based clients to work without client side changes while the redirect based clients will work with the new local authenticators.

The following configs need to be added to the `rest-auth.properties` file if the sms or email local authenticators are used in the application configuration.

```
#SMS OTP authenticator name sent in the request when the local sms otp authenticator is configured in the app
#When configured the same alias will be used in the responses instead of the local sms otp authenticator name
#If the local sms otp authenticator is not configured then this property can be omitted
RestAuth.smsOtpAuthenticatorAlias=sms-otp-authenticator

#Email OTP authenticator name sent in the request when the local email otp authenticator is configured in the app
#When configured the same alias will be used in the responses instead of the local email otp authenticator name
#If the local email otp authenticator is not configured then this property can be omitted
RestAuth.emailOtpAuthenticatorAlias=email-otp-authenticator
```

